### PR TITLE
docs(readme): rewrite for clarity, SEO and AI answer engines (EN + ES)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -1,74 +1,183 @@
-# VirtualBox Interactive Tutorial
-
 <!-- hide -->
+<div align="center">
 
-> By [@arnaldoperez](https://github.com/arnaldoperez) and [other contributors](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/graphs/contributors) at [4Geeks Academy](https://4geeksacademy.co/)
+# Instalar Windows en una máquina virtual
 
-![last commit](https://img.shields.io/github/last-commit/4geeksacademy/installing-windows-on-virtual-machine)
-[![build by developers](https://img.shields.io/badge/build_by-Developers-blue)](https://4geeks.com)
-[![build by developers](https://img.shields.io/twitter/follow/4geeksacademy?style=social&logo=twitter)](https://twitter.com/4geeksacademy)
+[![Tutorial certificado](https://img.shields.io/badge/4Geeks-tutorial%20certificado-2563eb)](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine)
+[![Autocorregido con LearnPack](https://img.shields.io/badge/LearnPack-autocorregido-2563eb)](https://github.com/learnpack/learnpack)
+[![Abrir en Codespaces](https://img.shields.io/badge/Abrir%20en-Codespaces-fb5a1f)](https://codespaces.new/?repo=4GeeksAcademy/installing-windows-on-virtual-machine)
 
-*Estas instrucciones [están disponibles en 🇪🇸 español](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/blob/main/README.es.md) :es:*
+*These instructions are also [available in English](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/blob/HEAD/README.md)*
+
+</div>
 <!-- endhide -->
 
-En ésta práctica instalaras VirtualBox en tu computadora y lo utilizarás para crear una máquina virtual con Windows 10. VirtualBox será tu laboratorio a lo largo del curso, donde tendrás máquinas virtuales con sistemas operativos distintos donde podrás experimentar cosas en un entorno controlado y sin afectar tu maquina principal.
-
-Los siguientes pasos en esta práctica son:
-
-1. Instalación VirtualBox
-2. Descarga de windows
-3. Creación de la maquina virtual
-4. Verificación la instalación
+Monta tu primer laboratorio de seguridad: este tutorial interactivo instala Windows 10 dentro de una máquina virtual de VirtualBox en 5 pasos guiados — instalar VirtualBox en Windows, Linux o macOS con Intel, crear un ISO de Windows 10 y montar la máquina con instalación desatendida. El último paso se autocorrige con 3 comprobaciones de Jest: que la máquina sea Windows 10 y tenga al menos 2048 MB de RAM y 2 CPUs.
 
 <!-- hide -->
+## 📋 Sobre este tutorial
 
-#### Antes de empezar...
+- **Dificultad:** fácil (`"difficulty": "easy"` en [learn.json](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/blob/HEAD/learn.json))
+- **Duración estimada:** 5 horas (`"duration": 5`)
+- **Pasos:** 5 ejercicios en orden, el último autocorregido
+- **Tecnologías:** ciberseguridad, windows (`"technologies"` en learn.json)
+- **Corrección:** LearnPack + Jest, 3 comprobaciones en un único fichero de test
+- **Idiomas:** español e inglés, paso a paso
+- **Dónde se ejecuta:** GitHub Codespaces o una instalación local de LearnPack (`"localhostOnly": true`)
+- **Código que tienes que escribir:** ninguno — aquí se configura una máquina virtual, no se programa
+<!-- endhide -->
 
-> ¡Te necesitamos! Estos ejercicios se crean y mantienen en colaboración con personas como tú. Si encuentras algún error o falta de ortografía, contribuye y/o repórtalo.
+## 🎯 ¿Qué vas a aprender?
 
-## Instalación en un clic (recomendado)
+La virtualización es lo primero que monta quien empieza en seguridad, porque es la única forma segura de romper cosas. Al terminar sabrás:
 
-Puedes empezar estos ejercicios en pocos segundos haciendo clic en: [Abrir en Codespaces](https://codespaces.new/?repo=4GeeksAcademy/installing-windows-on-virtual-machine).
+- Instalar **VirtualBox** en Windows con el asistente oficial, en Linux basado en Debian con un único `wget ... | sudo sh`, en distribuciones RPM (Oracle Linux/RHEL, Fedora, openSUSE) añadiendo el repositorio de Oracle, y en macOS con procesador Intel con el instalador `.dmg`.
+- Usar la **herramienta de creación de medios** de Microsoft para generar un archivo ISO en lugar de un USB, eligiendo tú la arquitectura en vez de copiar la del equipo donde la ejecutas.
+- Crear una máquina virtual en el **Modo experto** de VirtualBox: nombre, tipo de sistema operativo, imagen ISO y disco duro virtual.
+- Aprovechar la **instalación desatendida** para que VirtualBox rellene por ti todo el instalador de Windows, incluida la clave de producto genérica que instala Windows pero no lo activa.
+- Dimensionar el hardware de la máquina virtual — núcleos y memoria base — para que funcione bien **sin ahogar al equipo anfitrión**.
+- Leer la configuración real de una máquina desde la terminal con `VBoxManage showvminfo --machinereadable`, que es justo lo que el tutorial usa para comprobar tu trabajo.
 
-> Una vez ya tengas abierto VSCode, los ejercicios de LearnPack deberían empezar automáticamente, si esto no sucede puedes intentar empezar los ejercicios escribiendo este comando en tu terminal: `$ learnpack start`
+## 👀 ¿Qué vas a construir?
 
-## Instalación local:
+Una máquina virtual con Windows 10 funcionando, que VirtualBox reporte como Windows 10 y con al menos 2 CPUs y 2048 MB de memoria. Llegarás ahí con los 5 ejercicios de la carpeta `exercises/`:
 
-Clona el repositorio en tu ambiente local y sigue los siguientes pasos:
+1. **`01-welcome`** — el mapa del recorrido: qué es un laboratorio virtual y por qué lo peor que puede pasar dentro de él es tener que reinstalar la máquina.
+2. **`02-install-virtual-box`** — la instalación de VirtualBox, con un camino distinto para Windows, Linux Debian, Linux RPM y macOS con Intel.
+3. **`03-download-windows-iso`** — descargar la herramienta de creación de medios de Windows 10, aceptar los términos, elegir "Crear medios de instalación", personalizar la arquitectura y guardar el archivo `.iso`.
+4. **`04-create-new-vm`** — crear la máquina: tipo de sistema, ISO, instalación desatendida con clave de producto, mínimo 2 CPUs y 2 GB de memoria, y el almacenamiento recomendado.
+5. **`05-Verify-Installation`** — instalar `curl`, publicar el puerto `3001`, ejecutar el script de validación y pasar las pruebas.
 
-1. Instala LearnPack, el package manager para tutoriales de aprendizaje y el HTML compiler plugin para LearnPack, asegúrate también de tener node.js 14+:
+El paso del hardware es el que decide si apruebas. VirtualBox lo abre con **1 CPU seleccionada por defecto**, y ese valor no pasa el test:
 
-```bash
-$ npm i learnpack -g
-$ learnpack plugins:install learnpack-html
-```
+![Asistente Crear máquina virtual de VirtualBox en Modo experto, con la sección Hardware desplegada, el deslizador de Memoria base en 2048 MB y el de Procesadores todavía en su valor por defecto de 1 CPU, con los botones Terminar y Cancelar abajo](https://raw.githubusercontent.com/4GeeksAcademy/installing-windows-on-virtual-machine/master/.learn/assets/createvm3.png)
 
-2. Descarga estos ejercicios en particular usando LearnPack y luego `cd` para entrar en la carpeta:
+Sube el deslizador de Procesadores a 2 o más antes de pulsar Terminar.
 
-```bash
-$ learnpack download html-forms-tutorial-exercises
-$ cd html-forms-tutorial-exercises
-```
+## 🎓 ¿Qué necesitas antes de empezar?
 
-> Nota: Una vez que termines de descargar, encontrarás una carpeta "exercises" que contiene todos los ejercicios.
+- **Un equipo donde se pueda instalar VirtualBox:** Windows, un Linux Debian/Ubuntu o basado en RPM, o un Mac con procesador Intel. El tutorial enlaza el instalador de macOS solo para procesadores Intel, así que los Mac con Apple Silicon quedan fuera.
+- **Hardware libre para la máquina virtual:** al menos 2 núcleos y 2048 MB de RAM que el anfitrión pueda prestarle, más espacio en disco para el ISO de Windows 10 y para el disco duro virtual.
+- **Paciencia para dos descargas:** el ISO es un archivo muy pesado y, después, la instalación desatendida corre sola hasta que Windows arranca.
+- **`curl` en el equipo donde vive VirtualBox**, porque el script de validación lo usa para subir el informe. En Windows puedes instalarlo desde [curl.se/windows](https://curl.se/windows/).
+- **Una cuenta de GitHub** si prefieres hacer los ejercicios en Codespaces en lugar de instalar LearnPack en tu equipo.
+- **Nada de experiencia programando.** No hay código que escribir: el fichero de test ya viene hecho.
 
-3. Inicializa el tutorial/ejercicios ejecutando el siguiente comando en el mismo nivel donde se encuentra tu archivo learn.json:
+## ✅ ¿Cómo funciona la autocorrección?
 
-```bash
-$ npm i jest@24.8.0 -g
-$ learnpack start
-```
-## Colaboradores
+Solo se corrige el último ejercicio, y se corrige contra tu máquina real, no contra un texto que escribas. La cadena tiene cuatro eslabones:
 
-Gracias a estas personas maravillosas ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
+1. El Codespace ejecuta `.devcontainer/postCreate.sh` al arrancar, y ese script lanza `node server.js` — un pequeño receptor Express que escucha en el puerto indicado en `.env` (`HOST_PORT=3001`). LearnPack no lo arranca, así que fuera de un Codespace lo levantas tú.
+2. Publicas el puerto `3001` desde el panel **PUERTOS** de tu Codespace, para que tu propio equipo pueda alcanzarlo desde fuera.
+3. Descargas y descomprimes el script de validación — `sendDataWin.zip` para Windows, `sendDataBash.zip` para Linux —, lo ejecutas en el equipo donde está instalado VirtualBox y pegas la URL del puerto `3001` cuando te la pida. El script lanza `VBoxManage list vms`, vuelca `VBoxManage showvminfo --machinereadable` de cada máquina en `data.txt` y lo sube con `curl -X POST -F "file=@data.txt"`.
+4. El servidor interpreta ese volcado y escribe `vminfo.json`, que es lo que lee el test.
 
-1. [Arnaldo Perez (arnaloperez)](https://github.com/arnaloperez) cotribución: (build-tutorial) ✅, (documentación) 📖
-  
-2. [Alejandro Sanchez (alesanchezr)](https://github.com/alesanchezr),  contribución: (detector bugs) 🐛
+Publicar el puerto es el paso que más se olvida. En la pestaña de puertos, haz clic derecho sobre la fila del puerto `3001`, abre **Visibilidad del puerto** y elige **Public**:
 
-3. [Lorena Gubaira (lorenagubaira)](https://github.com/lorenagubaira), contribution: (detector bugs) 🐛, contribution: (editor), (tranducción) 🌎
+![Panel de puertos de Visual Studio Code dentro de un Codespace de GitHub, con la entrada node_server en el puerto 3001 y el menú contextual abierto en el submenú Visibilidad del puerto con la opción Public marcada](https://raw.githubusercontent.com/4GeeksAcademy/installing-windows-on-virtual-machine/master/.learn/assets/public-ports.png)
 
-Este proyecto sigue la especificación [all-contributors](https://github.com/kentcdodds/all-contributors). ¡Todas las contribuciones son bienvenidas!
+El fichero [`exercises/05-Verify-Installation/test.js`](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/blob/HEAD/exercises/05-Verify-Installation/test.js) ejecuta entonces 3 comprobaciones sobre la máquina cuyo `ostype` empieza por `Windows 10`:
 
-Este y otros ejercicios son usados para [aprender a programar](https://4geeksacademy.com/es/aprender-a-programar/aprender-a-programar-desde-cero) por parte de los alumnos de 4Geeks Academy [Coding Bootcamp](https://4geeksacademy.com/us/coding-bootcamp) realizado por [Alejandro Sánchez](https://twitter.com/alesanchezr) y muchos otros contribuyentes. Conoce más sobre nuestros [Cursos de Programación](https://4geeksacademy.com/es/curso-de-programacion-desde-cero?lang=es) para convertirte en [Full Stack Developer](https://4geeksacademy.com/es/coding-bootcamps/desarrollador-full-stack/?lang=es), o nuestro [Data Science Bootcamp](https://4geeksacademy.com/es/coding-bootcamps/curso-datascience-machine-learning).Tambien puedes adentrarte al mundo de ciberseguridad con nuestro [Bootcamp de ciberseguridad](https://4geeksacademy.com/es/coding-bootcamps/curso-ciberseguridad).
+- Esa máquina con Windows 10 tiene que existir en el informe.
+- Su valor de `memory` tiene que ser mayor o igual que `2048`.
+- Su valor de `cpus` tiene que ser mayor o igual que `2`.
+
+Si `vminfo.json` no está, la suite se corta antes de la primera comprobación con el mensaje `vminfo.json not found. Please run the BAT file on your local machine.`
+
+## 💡 ¿Qué errores conviene evitar?
+
+- **Ejecutar el script de validación dentro del Windows invitado.** El script llama a `VBoxManage`, que forma parte de VirtualBox y vive en el anfitrión, así que hay que lanzarlo en el equipo donde instalaste VirtualBox.
+- **Dejar el deslizador de Procesadores en 1.** Es el valor por defecto, y la tercera comprobación pide 2 o más. Una memoria base por debajo de 2048 MB falla igual.
+- **Dejar el puerto `3001` en privado.** El envío nunca llega, `vminfo.json` no se crea y todos los tests fallan con el error de "not found" aunque tu máquina virtual esté perfecta.
+- **Elegir otro tipo de sistema operativo.** El informe se compara contra `Windows 10`, así que una máquina creada como Windows 11 o como "Other" genérico no se reconoce.
+- **Saltarte la clave de producto en la instalación desatendida.** El tutorial avisa de que dejarla vacía provoca errores durante la instalación; la clave que te da instala Windows, pero no lo activa.
+- **Ejecutar el script sin descomprimirlo antes,** o pegar una URL que no sea la dirección reenviada del puerto `3001`.
+
+## ❓ Preguntas frecuentes
+
+### ¿Necesito una licencia de Windows para esto?
+
+La instalación desatendida usa una clave de producto genérica que permite terminar el instalador pero no activa Windows. Acabas con un Windows 10 sin activar, suficiente para el laboratorio y para pasar las pruebas.
+
+### ¿Puedo hacerlo en un Mac con Apple Silicon (M1, M2, M3)?
+
+Con estas instrucciones, no. El tutorial enlaza el `.dmg` de VirtualBox para procesadores Intel y cubre anfitriones Windows y Linux. En un Mac con Apple Silicon necesitarías otra herramienta de virtualización, que queda fuera de estos 5 pasos.
+
+### ¿Cuánta RAM y cuántas CPUs le doy a la máquina virtual?
+
+Como mínimo 2048 MB y 2 CPUs, porque son exactamente los mínimos que comprueban los tests. Subir de ahí hace que Windows vaya más fino, pero nunca le cedas tanto que el equipo anfitrión empiece a arrastrarse: la máquina virtual toma prestado el hardware, no lo añade.
+
+### ¿Tengo que escribir código?
+
+No. Los ejercicios son configuración y capturas de pantalla; el fichero de test ya está escrito y lo único que produces es una máquina virtual funcionando y el informe que sube el script.
+
+### ¿Por qué el test me dice `vminfo.json not found`?
+
+Porque el servidor nunca recibió tu informe. Lo habitual es que el puerto `3001` siga en privado, que hayas lanzado el script dentro de la máquina virtual en vez de en el anfitrión, o que la URL pegada no sea la dirección reenviada del puerto `3001`.
+
+### ¿Puedo hacer el tutorial sin GitHub Codespaces?
+
+Sí. Clona el repositorio, ejecuta LearnPack en tu equipo y arranca tú mismo el receptor con `node server.js`: fuera de un Codespace nadie lo levanta por ti. Entonces escuchará en `HOST_PORT=3001` en tu propia máquina, así que la dirección que pegas en el script de validación será `localhost:3001` en lugar de una URL de Codespaces.
+
+<!-- hide -->
+## 📝 Otros tutoriales interactivos
+
+- [Aprende Python Interactivamente (Principiante)](https://4geeks.com/es/interactive-exercise/python-beginner-exercises-es)
+- [Domina Python Practicando (interactivo)](https://4geeks.com/es/interactive-exercise/master-python-exercises-es)
+
+## 🚀 Cómo empezar
+
+Lo más rápido es [abrir el repositorio en Codespaces](https://codespaces.new/?repo=4GeeksAcademy/installing-windows-on-virtual-machine). Cuando se abra VS Code, los ejercicios de LearnPack deberían arrancar solos; si no lo hacen, escribe `learnpack start` en la terminal.
+
+Recuerda que la máquina virtual se crea en **tu propio ordenador**, no dentro del Codespace: el Codespace solo aloja las instrucciones y el servidor de validación.
+
+## 💻 Instalación local
+
+1. Clona el repositorio ([cómo clonar un repositorio](https://4geeks.com/how-to/github-clone-repository)) y entra en la carpeta:
+
+   ```bash
+   git clone https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine.git
+   cd installing-windows-on-virtual-machine
+   ```
+
+2. Instala LearnPack y el plugin compilador de node de forma global (necesitas Node.js):
+
+   ```bash
+   npm i @learnpack/learnpack -g
+   learnpack plugins:install @learnpack/node
+   ```
+
+3. Instala las dependencias del proyecto y arranca el tutorial al mismo nivel que `learn.json`:
+
+   ```bash
+   npm i
+   learnpack start
+   ```
+
+4. Para el último ejercicio, abre una segunda terminal y arranca el receptor de validación, que fuera de un Codespace no lo levanta nadie por ti:
+
+   ```bash
+   node server.js
+   ```
+
+## 📚 Cómo están organizados los ejercicios
+
+- `exercises/` contiene las 5 carpetas numeradas, y LearnPack las recorre en orden.
+- Cada carpeta tiene un `README.md` y un `README.es.md`, así que puedes cambiar de idioma en cualquier paso.
+- Solo `05-Verify-Installation` tiene `test.js`; los otros cuatro son de leer y hacer.
+- `learn.json` guarda la configuración del tutorial: título, descripción, duración, dificultad y tecnologías.
+- `server.js` es el receptor Express que convierte el volcado de VirtualBox en `vminfo.json`.
+- `.learn/assets/` guarda las capturas y los dos scripts de validación, empaquetados como `sendDataWin.zip` y `sendDataBash.zip`.
+
+## 🤝 Colaboradores
+
+Gracias a estas personas maravillosas:
+
+1. [Arnaldo Perez (arnaldoperez)](https://github.com/arnaldoperez), contribución: build-tutorial, documentación
+2. [Alejandro Sánchez (alesanchezr)](https://github.com/alesanchezr), contribución: detector de bugs
+3. [Lorena Gubaira (lorenagubaira)](https://github.com/lorenagubaira), contribución: detectora de bugs, editora, traducción
+
+Puedes ver la lista completa en el [gráfico de contribuidores](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/graphs/contributors). ¿Encontraste un fallo o una falta de ortografía? [Abre un issue](https://github.com/learnpack/learnpack/issues/new): estos ejercicios se construyen y se mantienen junto a personas como tú.
+
+Este y muchos otros tutoriales interactivos los crean estudiantes y mentores de 4Geeks Academy, y se usan en el [Bootcamp de Ciberseguridad](https://4geeksacademy.com/es/coding-bootcamps/curso-ciberseguridad).
 <!-- endhide -->

--- a/README.md
+++ b/README.md
@@ -1,66 +1,183 @@
-# VirtualBox Interactive Tutorial
-
 <!-- hide -->
+<div align="center">
 
-> By [@arnaldoperez](https://github.com/arnaldoperez) and [other contributors](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/graphs/contributors) at [4Geeks Academy](https://4geeksacademy.co/)
+# Installing Windows on a Virtual Machine
 
-![last commit](https://img.shields.io/github/last-commit/4geeksacademy/installing-windows-on-virtual-machine)
-[![build by developers](https://img.shields.io/badge/build_by-Developers-blue)](https://4geeks.com)
-[![build by developers](https://img.shields.io/twitter/follow/4geeksacademy?style=social&logo=twitter)](https://twitter.com/4geeksacademy)
+[![Certified tutorial](https://img.shields.io/badge/4Geeks-certified%20tutorial-2563eb)](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine)
+[![Autograded with LearnPack](https://img.shields.io/badge/LearnPack-autograded-2563eb)](https://github.com/learnpack/learnpack)
+[![Open in Codespaces](https://img.shields.io/badge/Open%20in-Codespaces-fb5a1f)](https://codespaces.new/?repo=4GeeksAcademy/installing-windows-on-virtual-machine)
 
-*Estas instrucciones [están disponibles en 🇪🇸 español](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/blob/master/README.es.md) :es:*
+*These instructions are also [available in Spanish](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/blob/HEAD/README.es.md)*
 
+</div>
 <!-- endhide -->
 
-In this exercise, you will install VirtualBox on your computer and use it to create a virtual machine with Windows 10. VirtualBox will be your lab throughout the course, where you will have virtual machines with different operating systems where you can experiment in a controlled environment without affecting your main machine.
-
-The following steps in this exercise are:
-
-1. VirtualBox installation
-2. Windows download
-3. Creation of the virtual machine
-4. Verification of the installation
+Build your first security lab: this interactive tutorial installs Windows 10 inside a VirtualBox virtual machine in 5 guided steps — installing VirtualBox on Windows, Linux or Intel macOS, creating a Windows 10 ISO, and building the machine with an unattended install. The last step is autograded by 3 Jest assertions that check the guest is Windows 10 with at least 2048 MB of RAM and 2 CPUs.
 
 <!-- hide -->
-## Before you start...
+## 📋 About this tutorial
 
-> We need you! These exercises are built and maintained in collaboration with contributors such as yourself. If you find any bugs or misspellings please contribute and/or report them.
+- **Difficulty:** easy (`"difficulty": "easy"` in [learn.json](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/blob/HEAD/learn.json))
+- **Estimated duration:** 5 hours (`"duration": 5`)
+- **Steps:** 5 sequential exercises, the last one autograded
+- **Technologies:** cybersecurity, windows (`"technologies"` in learn.json)
+- **Grading:** LearnPack + Jest, 3 assertions in a single test file
+- **Languages:** English and Spanish, step by step
+- **Where it runs:** GitHub Codespaces or a local LearnPack install (`"localhostOnly": true`)
+- **Code you have to write:** none — you configure a virtual machine, not a program
+<!-- endhide -->
 
-## One click installation (recommended):
+## 🎯 What will you learn?
 
-You can open these exercises in just a few seconds by clicking: [Open in Codespaces](https://codespaces.new/?repo=4GeeksAcademy/installing-windows-on-virtual-machine).
+Virtualization is the first tool a security student sets up, because it is the only safe way to break things. By the end of this tutorial you will know how to:
 
-> Once you have VSCode open the LearnPack exercises should start automatically. If exercises don't run automatically, you can try typing on your terminal: `$ learnpack start`
+- Install **VirtualBox** on Windows with the official wizard, on Debian-based Linux with a single `wget ... | sudo sh` command, on RPM distributions (Oracle Linux/RHEL, Fedora, openSUSE) by adding the Oracle repository, and on Intel-based macOS with the `.dmg` installer.
+- Turn Microsoft's **Media Creation Tool** into an ISO file instead of a USB stick, choosing the architecture yourself instead of copying the host's configuration.
+- Create a virtual machine in VirtualBox **Expert Mode**: name, operating system type, ISO image and virtual disk.
+- Use **unattended installation** so VirtualBox types the whole Windows setup for you, including the generic product key that installs Windows without activating it.
+- Size the guest hardware — CPU cores and base memory — so the virtual machine works well **without starving the host**.
+- Read a machine's real configuration from the command line with `VBoxManage showvminfo --machinereadable`, which is how the tutorial proves your machine exists.
 
-## Local Installation
+## 👀 What will you build?
 
-Clone this repository in your local environment ([Clone this repository](https://4geeks.com/how-to/github-clone-repository)) and follow the steps below:
+A running Windows 10 virtual machine that VirtualBox reports as Windows 10, with at least 2 CPUs and 2048 MB of memory. You get there through 5 exercises inside the `exercises/` folder:
 
-1. Install LearnPack, the package manager for learning tutorials and the node compiler plugin for learnpack, make sure you also have node.js 14:
+1. **`01-welcome`** — the roadmap: what a virtual lab is and why the worst thing that can happen inside it is having to reinstall the machine.
+2. **`02-install-virtual-box`** — VirtualBox installation, with a separate path for Windows, Debian-based Linux, RPM-based Linux and Intel macOS.
+3. **`03-download-windows-iso`** — downloading the Windows 10 media creation tool, accepting the terms, choosing "Create installation media", picking the architecture and saving an `.iso` file.
+4. **`04-create-new-vm`** — creating the machine: OS type, ISO, unattended installation with a product key, at least 2 CPUs and 2 GB of memory, and the recommended storage configuration.
+5. **`05-Verify-Installation`** — installing `curl`, publishing port `3001`, running the validation script and passing the tests.
 
-```bash
-$ npm i @learnpack/learnpack -g
-```
+The hardware step is the one that decides whether you pass. VirtualBox opens it with **1 CPU selected by default**, and that value fails the test:
 
-2. Start the tutorial/exercises by running the following command at the same level where your learn.json file is:
+![VirtualBox Create Virtual Machine wizard in Expert Mode with a Spanish interface, Hardware section expanded, showing the Base Memory (Memoria base) slider set to 2048 MB and the Processors (Procesadores) slider still at its default of 1 CPU, with the Finish (Terminar) and Cancel (Cancelar) buttons at the bottom](https://raw.githubusercontent.com/4GeeksAcademy/installing-windows-on-virtual-machine/master/.learn/assets/createvm3.png)
 
-```bash
-$ learnpack start
-```
+Move the Processors slider to 2 or more before clicking Finish. The tutorial's screenshots were taken on a Spanish VirtualBox, so those two controls appear there as *Procesadores* and *Terminar*.
 
+## 🎓 What do you need before starting?
 
-## Contributors
+- **A computer where VirtualBox can be installed:** Windows, a Debian/Ubuntu or RPM-based Linux, or a Mac with an Intel CPU. The tutorial links the macOS installer for Intel processors only, so Apple Silicon machines are not covered.
+- **Spare hardware for the guest:** at least 2 processor cores and 2048 MB of RAM that the host can lend to the virtual machine, plus room on disk for the Windows 10 ISO and the virtual hard drive.
+- **Patience for two downloads:** the ISO is a large file, and the unattended installation then runs on its own until Windows boots.
+- **`curl` on the machine that hosts VirtualBox**, because the validation script uses it to upload the report. Windows users can install it from [curl.se/windows](https://curl.se/windows/).
+- **A GitHub account** if you want to run the exercises in Codespaces instead of installing LearnPack locally.
+- **No programming experience.** There is nothing to code: the only test file is written for you.
 
-Thanks goes to these wonderful people ([emoji key](https://github.com/kentcdodds/all-contributors#emoji-key)):
+## ✅ How does the automatic grading work?
 
-1. [Arnaldo Perez (arnaloperez)](https://github.com/arnaloperez) contribution: (build-tutorial) ✅, (documentation) 📖
-  
-2. [Alejandro Sanchez (alesanchezr)](https://github.com/alesanchezr),  contribution: (bug reports) 🐛
+Only the last exercise is graded, and it is graded against your real machine instead of against text you type. The chain has four links:
 
-3. [Lorena Gubaira (lorenagubaira)](https://github.com/lorenagubaira), contribution: (bug reports) 🐛, contribution: (editor), (translation) 🌎
+1. The Codespace runs `.devcontainer/postCreate.sh` when it starts, and that script launches `node server.js` — a small Express receiver that listens on the port set in `.env` (`HOST_PORT=3001`). LearnPack does not start it, so outside a Codespace you launch it yourself.
+2. You make port `3001` public from the **PORTS** panel of your Codespace, so your own computer can reach it from outside.
+3. You download and unzip the validation script — `sendDataWin.zip` for Windows, `sendDataBash.zip` for Linux — run it on the computer where VirtualBox lives, and paste the URL of port `3001` when it asks for it. The script runs `VBoxManage list vms`, dumps `VBoxManage showvminfo --machinereadable` for every machine into `data.txt` and uploads it with `curl -X POST -F "file=@data.txt"`.
+4. The server parses that dump and writes `vminfo.json`, which the test reads.
 
-This project follows the [all-contributors](https://github.com/kentcdodds/all-contributors) specification. Contributions of any kind are welcome!
+Publishing the port is the step people skip. In the PORTS tab, right click the row for port `3001`, open **Port visibility** and choose **Public**:
 
-This and many other exercises are built by students as part of the 4Geeks Academy [Coding Bootcamp](https://4geeksacademy.com/us/coding-bootcamp) by [Alejandro Sánchez](https://twitter.com/alesanchezr) and many other contributors. Find out more about our [Full Stack Developer Course](https://4geeksacademy.com/us/coding-bootcamps/part-time-full-stack-developer), and  [Data Science Bootcamp](https://4geeksacademy.com/us/coding-bootcamps/datascience-machine-learning).You can alse deepdive in the world of cybersecurity with our [Cybersecurity Bootcamp](https://4geeksacademy.com/us/coding-bootcamps/cybersecurity)
+![Visual Studio Code PORTS panel inside a GitHub Codespace, Spanish interface, showing the node_server entry on port 3001 and the right-click context menu open on the Port visibility (Visibilidad del puerto) submenu with the Public option selected](https://raw.githubusercontent.com/4GeeksAcademy/installing-windows-on-virtual-machine/master/.learn/assets/public-ports.png)
 
+The test file [`exercises/05-Verify-Installation/test.js`](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/blob/HEAD/exercises/05-Verify-Installation/test.js) then runs 3 assertions against the machine whose `ostype` starts with `Windows 10`:
+
+- The Windows 10 machine must exist in the report.
+- Its `memory` value must be greater than or equal to `2048`.
+- Its `cpus` value must be greater than or equal to `2`.
+
+If `vminfo.json` is not there, the whole suite stops before the first assertion with the message `vminfo.json not found. Please run the BAT file on your local machine.`
+
+## 💡 What mistakes should you avoid?
+
+- **Running the validation script inside the Windows guest.** The script calls `VBoxManage`, which is part of VirtualBox and lives on the host, so it has to run on the computer where VirtualBox is installed.
+- **Leaving the Processors slider at 1.** It is the default, and the third assertion asks for 2 or more. Base memory below 2048 MB fails in the same way.
+- **Leaving port `3001` private.** The upload never arrives, `vminfo.json` is never written, and every test fails with the "not found" error even though your virtual machine is perfectly fine.
+- **Choosing a different operating system type.** The report is matched against `Windows 10`, so a machine created as Windows 11 or as a generic "Other" type is not recognised.
+- **Skipping the product key in the unattended installation.** The tutorial is explicit that leaving it empty causes errors during setup; the key it gives you installs Windows but does not activate it.
+- **Running the script without unzipping it first,** or pasting a URL that is not the forwarded address of port `3001`.
+
+## ❓ Frequently asked questions
+
+### Do I need a Windows licence for this?
+
+The unattended installation uses a generic product key that lets the installer finish but does not activate Windows. You end up with an unactivated Windows 10 for lab use, which is enough for the exercises and for the tests.
+
+### Can I do this on a Mac with Apple Silicon (M1, M2, M3)?
+
+Not with these instructions. The tutorial links the VirtualBox `.dmg` for Intel processors, and covers Windows and Linux hosts. On an Apple Silicon Mac you would need a different virtualization tool, which is outside the scope of these 5 steps.
+
+### How much RAM and how many CPUs should I give the virtual machine?
+
+At least 2048 MB and 2 CPUs, because those are the exact minimums the tests check. Going higher makes Windows smoother, but never give away so much that the host machine starts to struggle — the guest borrows the hardware, it does not add any.
+
+### Do I have to write any code?
+
+No. The exercises are configuration and screenshots; the test file is already written and the only thing you produce is a working virtual machine and the report the script uploads.
+
+### Why does my test say `vminfo.json not found`?
+
+Because the server never received your report. The usual causes are port `3001` still being private, the script being run inside the guest instead of on the host, or the URL you pasted not matching the forwarded address of port `3001`.
+
+### Can I do the tutorial without GitHub Codespaces?
+
+Yes. Clone the repository, run LearnPack locally and start the receiver yourself with `node server.js` — outside a Codespace nothing launches it for you. It then listens on `HOST_PORT=3001` on your own machine, so the address you paste into the validation script is `localhost:3001` instead of a Codespaces URL.
+
+<!-- hide -->
+## 📝 Other interactive tutorials
+
+- [Learn Python Interactively (beginner)](https://4geeks.com/en/interactive-exercise/python-beginner-exercises)
+- [Master Python by practice (interactive)](https://4geeks.com/en/interactive-exercise/master-python-exercises)
+
+## 🚀 How to start
+
+The fastest way is [opening the repository in Codespaces](https://codespaces.new/?repo=4GeeksAcademy/installing-windows-on-virtual-machine). Once VS Code is open, the LearnPack exercises should start on their own; if they do not, type `learnpack start` in the terminal.
+
+Remember that the virtual machine itself is created on **your own computer**, not inside the Codespace: the Codespace only hosts the instructions and the validation server.
+
+## 💻 Local installation
+
+1. Clone the repository ([how to clone a repository](https://4geeks.com/how-to/github-clone-repository)) and enter the folder:
+
+   ```bash
+   git clone https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine.git
+   cd installing-windows-on-virtual-machine
+   ```
+
+2. Install LearnPack and the node compiler plugin globally (Node.js is required):
+
+   ```bash
+   npm i @learnpack/learnpack -g
+   learnpack plugins:install @learnpack/node
+   ```
+
+3. Install the project dependencies and start the tutorial at the same level as `learn.json`:
+
+   ```bash
+   npm i
+   learnpack start
+   ```
+
+4. For the last exercise, open a second terminal and start the validation receiver, which nothing launches for you outside a Codespace:
+
+   ```bash
+   node server.js
+   ```
+
+## 📚 How the exercises are organized
+
+- `exercises/` contains the 5 numbered folders, and LearnPack walks them in order.
+- Every folder has a `README.md` and a `README.es.md`, so you can switch language at any step.
+- Only `05-Verify-Installation` has a `test.js`; the other four are reading and doing.
+- `learn.json` holds the tutorial configuration: title, description, duration, difficulty and technologies.
+- `server.js` is the Express receiver that turns the VirtualBox dump into `vminfo.json`.
+- `.learn/assets/` stores the screenshots and the two validation scripts, packed as `sendDataWin.zip` and `sendDataBash.zip`.
+
+## 🤝 Contributors
+
+Thanks to these wonderful people:
+
+1. [Arnaldo Perez (arnaldoperez)](https://github.com/arnaldoperez), contribution: build-tutorial, documentation
+2. [Alejandro Sánchez (alesanchezr)](https://github.com/alesanchezr), contribution: bug reports
+3. [Lorena Gubaira (lorenagubaira)](https://github.com/lorenagubaira), contribution: bug reports, editor, translation
+
+See the full list on the [contributors graph](https://github.com/4GeeksAcademy/installing-windows-on-virtual-machine/graphs/contributors). Found a bug or a typo? [Open an issue](https://github.com/learnpack/learnpack/issues/new) — these exercises are built and maintained together with people like you.
+
+This and many other interactive tutorials are built by 4Geeks Academy students and mentors, and used in the [Cybersecurity Bootcamp](https://4geeksacademy.com/us/coding-bootcamps/cybersecurity).
 <!-- endhide -->


### PR DESCRIPTION
Rewrite of the root README in **both languages**, for clarity, search engines and AI answer engines. No content removed: everything that was there is either still visible or moved inside `<!-- hide -->`.

## Why some sections moved inside `<!-- hide -->`

Everything between those markers is stripped before the README is published on `4geeks.com`, but still shows here on GitHub. The platform already renders its own `h1` and its own stats (skill level, duration) from the database, so repeating them in the body shows up twice and can drift out of sync. Title, badges, the metadata block, install steps, repo layout and contributors now live there.

## What was added to the published part

An opening summary, what you will learn, what you will build (the real exercises, counted), prerequisites, common mistakes taken from the exercise content itself, and an FAQ with one `###` heading per question.

## Two constraints worth knowing

- **No markdown tables in the published part.** The `4geeks.com` renderer has no table extension, so a table shows up there as raw pipes and dashes. Lists are used instead.
- **Code fences inside a numbered list must be indented.** At column 0 they close the list, which splits it into several `<ol>` blocks and restarts the numbering. This was happening and is fixed.

Every link in both files was verified — and on `4geeks.com` specifically by reading the rendered body, because that domain returns HTTP 200 for URLs that do not exist.

Happy to adjust tone, wording or structure. If the direction looks right, the same treatment can be applied to the rest of the exercise repos.
